### PR TITLE
Added Enter and Escape Action Handeling

### DIFF
--- a/TempoChanges.qml
+++ b/TempoChanges.qml
@@ -269,6 +269,13 @@ MuseScore {
                   id: startTextValue
                   placeholderText: 'rit. / accel.'
                   implicitHeight: 24
+                  onAccepted: {
+                        applyTempoChanges();
+                        Qt.quit();
+                  }
+                  Keys.onEscapePressed: {
+                        Qt.quit();
+                  }
             }
             Canvas {
                   id: canvas
@@ -395,6 +402,13 @@ MuseScore {
                   validator: DoubleValidator { bottom: 1;/* top: 512;*/ decimals: 1; notation: DoubleValidator.StandardNotation; }
                   implicitHeight: 24
                   onTextChanged: { canvas.requestPaint(); }
+                  onAccepted: {
+                        applyTempoChanges();
+                        Qt.quit();
+                  }
+                  Keys.onEscapePressed: {
+                        Qt.quit();
+                  }
             }
 
             Label {
@@ -406,6 +420,13 @@ MuseScore {
                   validator: DoubleValidator { bottom: 1;/* top: 512;*/ decimals: 1; notation: DoubleValidator.StandardNotation; }
                   implicitHeight: 24
                   onTextChanged: { canvas.requestPaint(); }
+                  onAccepted: {
+                        applyTempoChanges();
+                        Qt.quit();
+                  }
+                  Keys.onEscapePressed: {
+                        Qt.quit();
+                  }
             }
 
             ComboBox {


### PR DESCRIPTION
If user is in one of the three text fields, pressing enter or escape triggers the common known sequence.
Enter: Applies effect and closes window
Escape: Just close window

This was requested by issue #17 